### PR TITLE
update rtd badge url

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@ Introduction
 ============
 
 
-.. image:: https://readthedocs.org/projects/adafruit-circuitpython-s35710/badge/?version=latest
+.. image:: https://readthedocs.org/projects/adafruit-circuitpython-s-35710/badge/?version=latest
     :target: https://docs.circuitpython.org/projects/s35710/en/latest/
     :alt: Documentation Status
 


### PR DESCRIPTION
the rtd slug for this project is `adafruit-circuitpython-s-35710`.  https://app.readthedocs.org/projects/adafruit-circuitpython-s-35710/builds/

This being mismatched also causes issues for adabot, first noticed here: https://github.com/adafruit/adabot/pull/394